### PR TITLE
fix typo in capability pattern

### DIFF
--- a/src/capability.md
+++ b/src/capability.md
@@ -29,7 +29,7 @@ module examples::item {
 
     /// Module initializer is called once on module publish.
     /// Here we create only one instance of `AdminCap` and send it to the publisher.
-    fun item(ctx: &mut TxContext) {
+    fun init(ctx: &mut TxContext) {
         transfer::transfer(AdminCap {
             id: tx_context::new_id(ctx)
         }, tx_context::sender(ctx))


### PR DESCRIPTION
Fix one typo in capability.md
It seems to be `fun init`